### PR TITLE
 fix: remove transition on positioner to prevent dropdown sliding from top-left in Firefox

### DIFF
--- a/src/components/ui/navigation-menu-1.tsx
+++ b/src/components/ui/navigation-menu-1.tsx
@@ -132,7 +132,7 @@ function NavigationMenuPositioner({
         collisionPadding={{ top: 5, bottom: 5, left: 16, right: 16 }}
         collisionAvoidance={{ side: "none" }}
         className={cn(
-          "z-[200] box-border h-[var(--positioner-height)] w-[var(--positioner-width)] max-w-[var(--available-width)] transition-[top,left,right,bottom] duration-[var(--duration)] ease-[var(--easing)] before:absolute before:content-[''] data-[instant]:transition-none data-[side=bottom]:before:top-[-10px] data-[side=bottom]:before:right-0 data-[side=bottom]:before:left-0 data-[side=bottom]:before:h-2.5 data-[side=left]:before:top-0 data-[side=left]:before:right-[-10px] data-[side=left]:before:bottom-0 data-[side=left]:before:w-2.5 data-[side=right]:before:top-0 data-[side=right]:before:bottom-0 data-[side=right]:before:left-[-10px] data-[side=right]:before:w-2.5 data-[side=top]:before:right-0 data-[side=top]:before:bottom-[-10px] data-[side=top]:before:left-0 data-[side=top]:before:h-2.5",
+          "z-[200] box-border h-[var(--positioner-height)] w-[var(--positioner-width)] max-w-[var(--available-width)] before:absolute before:content-[''] data-[side=bottom]:before:top-[-10px] data-[side=bottom]:before:right-0 data-[side=bottom]:before:left-0 data-[side=bottom]:before:h-2.5 data-[side=left]:before:top-0 data-[side=left]:before:right-[-10px] data-[side=left]:before:bottom-0 data-[side=left]:before:w-2.5 data-[side=right]:before:top-0 data-[side=right]:before:bottom-0 data-[side=right]:before:left-[-10px] data-[side=right]:before:w-2.5 data-[side=top]:before:right-0 data-[side=top]:before:bottom-[-10px] data-[side=top]:before:left-0 data-[side=top]:before:h-2.5",
           className,
         )}
         style={


### PR DESCRIPTION
Issue: When hovering over this dropdown tab in Firefox, the dropdown content sometimes appears from top left of the page and slowly comes back to its correct position.

Reproduction:
<img width="1180" height="672" alt="image" src="https://github.com/user-attachments/assets/3cf63b86-6cda-430e-9524-8877dce04042" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed a position animation from the navigation menu so it appears and updates more instantly, improving responsiveness and reducing motion during navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->